### PR TITLE
jl changed the default status of users to student = true

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -37,7 +37,7 @@ public class User {
   @Builder.Default
   private Boolean admin=false;
   @Builder.Default
-  private Boolean student=false;
+  private Boolean student=true;
   @Builder.Default
   private Boolean professor=false;
 }


### PR DESCRIPTION
closes #23 

In this PR, I change the default status of new users to student. New users in the table will now have the student field set to true.

![image](https://github.com/user-attachments/assets/b86c02eb-abdc-4fde-ab82-cad63e2a9254)