### PR TITLE
dk - added recommendation request table to pending requests page

### DIFF
--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -17,10 +17,10 @@ export default function PendingRequestsPage() {
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
     [apiEndpoint],
-    { 
+    {
       // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
-      method: "GET", 
-      url: apiEndpoint 
+      method: "GET",
+      url: apiEndpoint,
     },
     // Stryker disable next-line all : don't test default value of empty list
     [],

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -17,7 +17,11 @@ export default function PendingRequestsPage() {
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
     [apiEndpoint],
-    { method: "GET", url: apiEndpoint },
+    { 
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET", 
+      url: apiEndpoint 
+    },
     // Stryker disable next-line all : don't test default value of empty list
     [],
   );

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -26,13 +26,17 @@ export default function PendingRequestsPage() {
     [],
   );
 
+  const pendingRequests = requests.filter(
+    (request) => request.status === "PENDING",
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Pending Requests</h1>
         <div data-testid="RecommendationRequestTable">
           <RecommendationRequestTable
-            requests={requests}
+            requests={pendingRequests}
             currentUser={currentUser}
           />
         </div>

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -1,11 +1,38 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend } from "main/utils/useBackend";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
   // Stryker disable all : placeholder for future implementation
+  const { data: currentUser } = useCurrentUser();
+
+  const apiEndpoint = hasRole(currentUser, "ROLE_PROFESSOR")
+    ? "/api/recommendationrequest/professor/all"
+    : "/api/recommendationrequest/requester/all";
+
+  const {
+    data: requests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [apiEndpoint],
+    { method: "GET", url: apiEndpoint },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Pending Requests page not yet implemented</h1>
+        <h1>Pending Requests</h1>
+        <div data-testid="RecommendationRequestTable">
+          <RecommendationRequestTable
+            requests={requests}
+            currentUser={currentUser}
+          />
+        </div>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Requests/PendingRequestsPage.js
+++ b/frontend/src/main/pages/Requests/PendingRequestsPage.js
@@ -4,7 +4,6 @@ import RecommendationRequestTable from "main/components/RecommendationRequest/Re
 import { useCurrentUser, hasRole } from "main/utils/currentUser";
 
 export default function PendingRequestsPage() {
-  // Stryker disable all : placeholder for future implementation
   const { data: currentUser } = useCurrentUser();
 
   const apiEndpoint = hasRole(currentUser, "ROLE_PROFESSOR")

--- a/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
+++ b/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
@@ -27,8 +27,8 @@ Empty.parameters = {
   ],
 };
 
-export const ThreeRequests = Template.bind({});
-ThreeRequests.parameters = {
+export const PendingRequests = Template.bind({});
+PendingRequests.parameters = {
   msw: [
     http.get("/api/currentUser", () => {
       return HttpResponse.json(apiCurrentUserFixtures.professorUser);
@@ -37,7 +37,9 @@ ThreeRequests.parameters = {
       return HttpResponse.json(systemInfoFixtures.showingNeither);
     }),
     http.get("/api/recommendationrequest/professor/all", () => {
-      return HttpResponse.json(recommendationRequestFixtures.mixedRequests);
+      return HttpResponse.json([
+        recommendationRequestFixtures.mixedRequests[2],
+      ]);
     }),
   ],
 };

--- a/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
+++ b/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
@@ -1,0 +1,44 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "pages/Requests/PendingRequestsPage",
+  component: PendingRequestsPage,
+};
+
+const Template = () => <PendingRequestsPage />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.professorUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/recommendationrequest/professor/all", () => {
+      return HttpResponse.json([]);
+    }),
+  ],
+};
+
+export const ThreeRequests = Template.bind({});
+ThreeRequests.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.professorUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/recommendationrequest/professor/all", () => {
+      return HttpResponse.json(recommendationRequestFixtures.mixedRequests);
+    }),
+  ],
+};
+

--- a/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
+++ b/frontend/src/stories/pages/Requests/PendingRequestsPage.stories.js
@@ -41,4 +41,3 @@ ThreeRequests.parameters = {
     }),
   ],
 };
-

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -47,7 +47,7 @@ describe("PendingRequestsPage tests", () => {
     await screen.findByText("Pending Requests");
   });
 
-  test("Renders completed and denied requests for professor", async () => {
+  test("Renders pending requests for professor", async () => {
     axiosMock
       .onGet("/api/currentUser")
       .reply(200, apiCurrentUserFixtures.professorUser);
@@ -86,10 +86,10 @@ describe("PendingRequestsPage tests", () => {
     );
     expect(
       statusCells.some((cell) => cell.textContent === "COMPLETED"),
-    ).toBeTruthy();
+    ).toBeFalsy();
     expect(
       statusCells.some((cell) => cell.textContent === "DENIED"),
-    ).toBeTruthy();
+    ).toBeFalsy();
     expect(
       statusCells.some((cell) => cell.textContent === "PENDING"),
     ).toBeTruthy();
@@ -165,10 +165,10 @@ describe("PendingRequestsPage tests", () => {
     );
     expect(
       statusCells.some((cell) => cell.textContent === "COMPLETED"),
-    ).toBeTruthy();
+    ).toBeFalsy();
     expect(
       statusCells.some((cell) => cell.textContent === "DENIED"),
-    ).toBeTruthy();
+    ).toBeFalsy();
     expect(
       statusCells.some((cell) => cell.textContent === "PENDING"),
     ).toBeTruthy();

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -38,6 +38,6 @@ describe("PendingRequestsPage tests", () => {
     );
 
     // assert
-    await screen.findByText("Pending Requests page not yet implemented");
+    await screen.findByText("Pending Requests");
   });
 });

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,9 +7,11 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
 describe("PendingRequestsPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+  const queryClient = new QueryClient();
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,7 +24,12 @@ describe("PendingRequestsPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+
+
   test("Renders expected content", async () => {
     // arrange
 
@@ -39,5 +46,161 @@ describe("PendingRequestsPage tests", () => {
 
     // assert
     await screen.findByText("Pending Requests");
+  });
+
+  test("Renders completed and denied requests for professor", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.professorUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock
+      .onGet("/api/recommendationrequest/professor/all")
+      .reply(200, recommendationRequestFixtures.mixedRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Pending Requests")).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
+      ).toBeInTheDocument();
+    });
+
+    const statusCells = screen.getAllByTestId(
+      /RecommendationRequestTable-cell-row-.*-col-status/,
+    );
+    expect(
+      statusCells.some((cell) => cell.textContent === "COMPLETED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.some((cell) => cell.textContent === "DENIED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.some((cell) => cell.textContent === "PENDING"),
+    ).toBeTruthy();
+  });
+
+  test("Renders empty table when no completed requests", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.professorUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/professor/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+  });
+  
+  test("Renders pending requests for student", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.studentUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock
+      .onGet("/api/recommendationrequest/requester/all")
+      .reply(200, recommendationRequestFixtures.mixedRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-status`),
+      ).toBeInTheDocument();
+    });
+
+    const statusCells = screen.getAllByTestId(
+      /RecommendationRequestTable-cell-row-.*-col-status/,
+    );
+    expect(
+      statusCells.some((cell) => cell.textContent === "COMPLETED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.some((cell) => cell.textContent === "DENIED"),
+    ).toBeTruthy();
+    expect(
+      statusCells.some((cell) => cell.textContent === "PENDING"),
+    ).toBeTruthy();
+  });
+
+  test("Renders empty table when no pending requests for student", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.studentUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/recommendationrequest/requester/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBe(3);
+    expect(
+      screen.getByTestId("RecommendationRequestTable"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -29,7 +29,6 @@ describe("PendingRequestsPage tests", () => {
     axiosMock.resetHistory();
   });
 
-
   test("Renders expected content", async () => {
     // arrange
 
@@ -124,7 +123,7 @@ describe("PendingRequestsPage tests", () => {
       screen.getByTestId("RecommendationRequestTable"),
     ).toBeInTheDocument();
   });
-  
+
   test("Renders pending requests for student", async () => {
     axiosMock
       .onGet("/api/currentUser")


### PR DESCRIPTION
Closes #12 

In this PR I updated the Pending Requests Page to add the recommendation requests table. 

To test, visit: https://rec-dk.dokku-16.cs.ucsb.edu/
1. Login
2. Go to Admin -> Users
3. Toggle Student and Professor to True.
4. Pending Requests should now appear in the Navbar (if nothing appears, refresh the page)
5. Recommendation Request Table should be visible on the Pending Requests Page.
6. Go into Swagger, use POST to create a recommendation request, and be sure to set status = "PENDING"
7. View pending request in the recommendation request table.

Storybook Link: https://6823e9b0211c5dd7ddc2cdd3-btqsdfpmrq.chromatic.com/?path=/story/pages-requests-pendingrequestspage--pending-requests

Screenshot:
<img width="1393" alt="Screenshot 2025-05-16 at 1 36 41 PM" src="https://github.com/user-attachments/assets/d7f2dcc7-3c10-4031-b67c-5c8b152db17c" />

