### PR TITLE
Jl user role

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9607,7 +9607,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9607,9 +9607,7 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001651",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -2,28 +2,6 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
-  // Stryker disable all : hard to test for query caching
-  function cellToAxiosParamsToggleStudent(cell) {
-    return {
-      url: "/api/admin/users/toggleStudent",
-      method: "POST",
-      params: {
-        id: cell.row.values.id,
-      },
-    };
-  }
-
-  const toggleStudentMutation = useBackendMutation(
-    cellToAxiosParamsToggleStudent,
-    {},
-    ["/api/admin/users"],
-  );
-  // Stryker enable all
-
-  // Stryker disable next-line all : TODO try to make a good test for this
-  const toggleStudentCallback = async (cell) => {
-    toggleStudentMutation.mutate(cell);
-  };
 
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
@@ -113,12 +91,6 @@ export default function UsersTable({ users }) {
       "Toggle Professor",
       "success",
       toggleProfessorCallback,
-      "UsersTable",
-    ),
-    ButtonColumn(
-      "Toggle Student",
-      "danger",
-      toggleStudentCallback,
       "UsersTable",
     ),
   ];

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -2,7 +2,6 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
-
   //toggleAdmin
   // Stryker disable next-line all : TODO try to make a good test for this
   function cellToAxiosParamsToggleAdmin(cell) {

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -78,11 +78,6 @@ export default function UsersTable({ users }) {
       id: "professor",
       accessor: (row, _rowIndex) => String(row.professor), // hack needed for boolean values to show up
     },
-    {
-      Header: "Student",
-      id: "student",
-      accessor: (row, _rowIndex) => String(row.student), // hack needed for boolean values to show up
-    },
   ];
 
   const buttonColumn = [

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -2,7 +2,9 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
+
   //toggleAdmin
+  // Stryker disable next-line all : TODO try to make a good test for this
   function cellToAxiosParamsToggleAdmin(cell) {
     return {
       url: "/api/admin/users/toggleAdmin",

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -2,7 +2,6 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
-
   //toggleAdmin
   function cellToAxiosParamsToggleAdmin(cell) {
     return {

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -2,6 +2,9 @@ import { render, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable";
 import { QueryClient, QueryClientProvider } from "react-query";
+import userEvent from "@testing-library/user-event";
+import { useBackendMutation } from "main/utils/useBackend";
+jest.mock("main/utils/useBackend");
 
 describe("UserTable tests", () => {
   const queryClient = new QueryClient();
@@ -84,5 +87,59 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-admin`),
     ).toHaveTextContent("false");
+  });
+});
+
+describe("UsersTable toggle callbacks", () => {
+  const queryClient = new QueryClient();
+
+  let mutateAdmin;
+  let mutateProfessor;
+
+  beforeEach(() => {
+    mutateAdmin = jest.fn();
+    mutateProfessor = jest.fn();
+
+    useBackendMutation
+      .mockImplementationOnce(() => ({ mutate: mutateAdmin }))
+      .mockImplementationOnce(() => ({ mutate: mutateProfessor }));
+  });
+
+  test("clicking Toggle Admin calls the admin mutate with the right cell", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UsersTable users={usersFixtures.threeUsers} />
+      </QueryClientProvider>,
+    );
+
+    const toggleAdminButtons = screen.getAllByRole("button", { name: "Toggle Admin" });
+    expect(toggleAdminButtons).toHaveLength(3);
+
+    await userEvent.click(toggleAdminButtons[0]);
+
+    expect(mutateAdmin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        row: expect.objectContaining({ index: 0 }),
+      })
+    );
+  });
+
+  test("clicking Toggle Professor calls the professor mutate with the right cell", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UsersTable users={usersFixtures.threeUsers} />
+      </QueryClientProvider>,
+    );
+
+    const toggleProfButtons = screen.getAllByRole("button", { name: "Toggle Professor" });
+    expect(toggleProfButtons).toHaveLength(3);
+
+    await userEvent.click(toggleProfButtons[2]);
+
+    expect(mutateProfessor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        row: expect.objectContaining({ index: 2 }),
+      })
+    );
   });
 });

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -36,7 +36,6 @@ describe("UserTable tests", () => {
       "Email",
       "Admin",
       "Professor",
-      "Student",
     ];
     const expectedFields = [
       "id",
@@ -45,7 +44,6 @@ describe("UserTable tests", () => {
       "email",
       "admin",
       "professor",
-      "student",
     ];
     const testId = "UsersTable";
 
@@ -68,9 +66,6 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-professor`),
     ).toHaveTextContent("false");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-student`),
-    ).toHaveTextContent("false");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
       "2",
     );
@@ -80,15 +75,9 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-1-col-professor`),
     ).toHaveTextContent("false");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-1-col-student`),
-    ).toHaveTextContent("true");
     expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
       "3",
     );
-    expect(
-      screen.getByTestId(`${testId}-cell-row-2-col-student`),
-    ).toHaveTextContent("false");
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-professor`),
     ).toHaveTextContent("true");

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -90,56 +90,64 @@ describe("UserTable tests", () => {
   });
 });
 
-describe("UsersTable toggle callbacks", () => {
+describe("UsersTable toggle-button hooks", () => {
   const queryClient = new QueryClient();
-
-  let mutateAdmin;
-  let mutateProfessor;
+  let spyAdmin, spyProf;
 
   beforeEach(() => {
-    mutateAdmin = jest.fn();
-    mutateProfessor = jest.fn();
+    spyAdmin = jest.fn();
+    spyProf = jest.fn();
 
     useBackendMutation
-      .mockImplementationOnce(() => ({ mutate: mutateAdmin }))
-      .mockImplementationOnce(() => ({ mutate: mutateProfessor }));
+      .mockImplementationOnce((cellToAxiosParams) => ({
+        mutate: (cell) => {
+          const axiosCfg = cellToAxiosParams(cell);
+          spyAdmin(axiosCfg);
+        },
+      }))
+      .mockImplementationOnce((cellToAxiosParams) => ({
+        mutate: (cell) => {
+          const axiosCfg = cellToAxiosParams(cell);
+          spyProf(axiosCfg);
+        },
+      }));
   });
 
-  test("clicking Toggle Admin calls the admin mutate with the right cell", async () => {
+  test("clicking Toggle Admin uses the correct URL/method/params", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <UsersTable users={usersFixtures.threeUsers} />
       </QueryClientProvider>,
     );
 
-    const toggleAdminButtons = screen.getAllByRole("button", { name: "Toggle Admin" });
-    expect(toggleAdminButtons).toHaveLength(3);
+    const buttons = screen.getAllByRole("button", { name: "Toggle Admin" });
+    expect(buttons).toHaveLength(3);
 
-    await userEvent.click(toggleAdminButtons[0]);
+    await userEvent.click(buttons[0]);
 
-    expect(mutateAdmin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        row: expect.objectContaining({ index: 0 }),
-      })
-    );
+    expect(spyAdmin).toHaveBeenCalledWith({
+      url: "/api/admin/users/toggleAdmin",
+      method: "POST",
+      params: { id: usersFixtures.threeUsers[0].id },
+    });
   });
 
-  test("clicking Toggle Professor calls the professor mutate with the right cell", async () => {
+  test("clicking Toggle Professor uses the correct URL/method/params", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <UsersTable users={usersFixtures.threeUsers} />
       </QueryClientProvider>,
     );
 
-    const toggleProfButtons = screen.getAllByRole("button", { name: "Toggle Professor" });
-    expect(toggleProfButtons).toHaveLength(3);
+    const buttons = screen.getAllByRole("button", { name: "Toggle Professor" });
+    expect(buttons).toHaveLength(3);
 
-    await userEvent.click(toggleProfButtons[2]);
+    await userEvent.click(buttons[2]);
 
-    expect(mutateProfessor).toHaveBeenCalledWith(
-      expect.objectContaining({
-        row: expect.objectContaining({ index: 2 }),
-      })
-    );
+    expect(spyProf).toHaveBeenCalledWith({
+      url: "/api/admin/users/toggleProfessor",
+      method: "POST",
+      params: { id: usersFixtures.threeUsers[2].id },
+    });
   });
 });


### PR DESCRIPTION
closes #18 

In this PR, I remove the button and table to toggle student status in the frontend. 

This can be verified by signing into https://rec-qa.dokku-16.cs.ucsb.edu/ with an admin email, and going to /admin/users

![image](https://github.com/user-attachments/assets/4eff8639-c51e-4953-9c70-620537d53a6d)
