### PR TITLE
cl - fixed completion date bug

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -132,8 +132,14 @@ public class RecommendationRequestController extends ApiController {
 
         recommendationRequest.setStatus(incoming.getStatus());
 
-        recommendationRequestRepository.save(recommendationRequest);
+       if ("COMPLETED".equalsIgnoreCase(incoming.getStatus())) {
+            recommendationRequest.setCompletionDate(LocalDateTime.now());
+        } 
+        else {
+            recommendationRequest.setCompletionDate(null);
+        }
 
+        recommendationRequestRepository.save(recommendationRequest);
         return recommendationRequest;
     }
 


### PR DESCRIPTION
Closes #6 

Fixes bug where completion date is not shown on the table. Completion date is now shown on the table for when a professor changes a request's status to COMPLETED.

<img width="759" alt="Screenshot 2025-05-19 at 9 35 58 PM" src="https://github.com/user-attachments/assets/1266e17e-f681-47be-8531-3f010abee31e" />

Can be tested by:
- Going to swagger
- Toggling as professor
- Create a request and then change the status to "COMPLETED"
- See completed request in completed request tab

