### PR TITLE
dk/cl - date completed stored in backend and displayed on table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -132,7 +132,7 @@ public class RecommendationRequestController extends ApiController {
 
         recommendationRequest.setStatus(incoming.getStatus());
 
-        if(incoming.getStatus().equals("COMPLETED") || incoming.getStatus().equals("DENIED")) {
+        if("COMPLETED".equals(incoming.getStatus()) || "DENIED".equals(incoming.getStatus())) {
             recommendationRequest.setCompletionDate(LocalDateTime.now());
         }
 

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestController.java
@@ -132,6 +132,10 @@ public class RecommendationRequestController extends ApiController {
 
         recommendationRequest.setStatus(incoming.getStatus());
 
+        if(incoming.getStatus().equals("COMPLETED") || incoming.getStatus().equals("DENIED")) {
+            recommendationRequest.setCompletionDate(LocalDateTime.now());
+        }
+
         recommendationRequestRepository.save(recommendationRequest);
 
         return recommendationRequest;

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -448,10 +448,10 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
         assertEquals("RecommendationRequest with id 67 not found", json.get("message"));
     }
 
-    //Prof can edit a Recommendation Request
+    //Prof can edit a Recommendation Request from PENDING to COMPLETED
     @WithMockUser(roles = {"PROFESSOR"})
     @Test
-    public void prof_can_put_recommendation_request() throws Exception {
+    public void prof_can_put_recommendation_request_completed() throws Exception {
         //arrange
         User student = User.builder().id(99).build(); 
         User prof = User.builder()
@@ -497,6 +497,88 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
                 .recommendationType("PhDprogram")
                 .details("details")
                 .status("COMPLETED")
+                .completionDate(LocalDateTime.now())
+                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .build();
+
+        String requestBody = mapper.writeValueAsString(rec_updated);
+
+        when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec)); 
+
+        //act
+        MvcResult response = mockMvc
+                .perform(put("/api/recommendationrequest/professor?id=67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //assert
+        verify(recommendationRequestRepository, times(1)).findById(67L);
+        verify(recommendationRequestRepository, times(1)).save(refEq(rec_corrected, "completionDate"));
+        
+        String responseString = response.getResponse().getContentAsString();
+        RecommendationRequest responseObject = mapper.readValue(responseString, RecommendationRequest.class);
+        assert(Duration.between(rec_corrected.getCompletionDate(), responseObject.getCompletionDate()).abs().getSeconds() < 5);
+        rec_corrected.setCompletionDate(responseObject.getCompletionDate());
+
+        String expectedJson = mapper.writeValueAsString(rec_corrected);
+        assertEquals(expectedJson, responseString);
+    }
+
+    //Prof can edit a Recommendation Request from PENDING to DENIED
+    @WithMockUser(roles = {"PROFESSOR"})
+    @Test
+    public void prof_can_put_recommendation_request_denied() throws Exception {
+        //arrange
+        User student = User.builder().id(99).build(); 
+        User prof = User.builder()
+                .id(22L)
+                .email("profA@ucsb.edu")
+                .googleSub("googleSub")
+                .fullName("Prof A")
+                .givenName("Prof")
+                .familyName("A")
+                .emailVerified(true)
+                .professor(true)
+                .build();
+
+        RecommendationRequest rec = RecommendationRequest.builder()
+                .id(67L)
+                .requester(student)
+                .professor(prof)
+                .recommendationType("PhDprogram")
+                .details("details")
+                .status("PENDING")
+                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .build();
+
+        RecommendationRequest rec_updated = RecommendationRequest.builder()
+                .id(67L)
+                .requester(student)
+                .professor(prof)
+                .recommendationType("PhDprogram")
+                .details("details")
+                .status("DENIED")
+                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .build();
+        RecommendationRequest rec_corrected = RecommendationRequest.builder()
+                .id(67L)
+                .requester(student)
+                .professor(prof)
+                .recommendationType("PhDprogram")
+                .details("details")
+                .status("DENIED")
                 .completionDate(LocalDateTime.now())
                 .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RecommendationRequestControllerTest.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.rec.controllers;
 import edu.ucsb.cs156.rec.entities.User;
 import edu.ucsb.cs156.rec.repositories.UserRepository;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -495,14 +497,13 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
                 .recommendationType("PhDprogram")
                 .details("details")
                 .status("COMPLETED")
-                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .completionDate(LocalDateTime.now())
                 .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
                 .build();
 
         String requestBody = mapper.writeValueAsString(rec_updated);
-        String expectedJson = mapper.writeValueAsString(rec_corrected);
 
         when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec)); 
 
@@ -518,9 +519,93 @@ public class RecommendationRequestControllerTest extends ControllerTestCase {
 
         //assert
         verify(recommendationRequestRepository, times(1)).findById(67L);
-        verify(recommendationRequestRepository, times(1)).save(rec_corrected);
-
+        verify(recommendationRequestRepository, times(1)).save(refEq(rec_corrected, "completionDate"));
+        
         String responseString = response.getResponse().getContentAsString();
+        RecommendationRequest responseObject = mapper.readValue(responseString, RecommendationRequest.class);
+        assert(Duration.between(rec_corrected.getCompletionDate(), responseObject.getCompletionDate()).abs().getSeconds() < 5);
+        rec_corrected.setCompletionDate(responseObject.getCompletionDate());
+
+        String expectedJson = mapper.writeValueAsString(rec_corrected);
+        assertEquals(expectedJson, responseString);
+    }
+
+    //Prof can edit a Recommendation Request
+    @WithMockUser(roles = {"PROFESSOR"})
+    @Test
+    public void prof_can_put_recommendation_request_with_status_pending_and_completed_date_does_not_appear() throws Exception {
+        //arrange
+        User student = User.builder().id(99).build(); 
+        User prof = User.builder()
+                .id(22L)
+                .email("profA@ucsb.edu")
+                .googleSub("googleSub")
+                .fullName("Prof A")
+                .givenName("Prof")
+                .familyName("A")
+                .emailVerified(true)
+                .professor(true)
+                .build();
+
+        RecommendationRequest rec = RecommendationRequest.builder()
+                .id(67L)
+                .requester(student)
+                .professor(prof)
+                .recommendationType("PhDprogram")
+                .details("details")
+                .status("PENDING")
+                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .build();
+
+        RecommendationRequest rec_updated = RecommendationRequest.builder()
+                .id(67L)
+                .requester(student)
+                .professor(prof)
+                .recommendationType("PhDprogram")
+                .details("details")
+                .status("PENDING")
+                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .build();
+        RecommendationRequest rec_corrected = RecommendationRequest.builder()
+                .id(67L)
+                .requester(student)
+                .professor(prof)
+                .recommendationType("PhDprogram")
+                .details("details")
+                .status("PENDING")
+                .completionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .dueDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .submissionDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .lastModifiedDate(LocalDateTime.parse("2022-01-03T00:00:00"))
+                .build();
+
+        String requestBody = mapper.writeValueAsString(rec_updated);
+
+        when(recommendationRequestRepository.findById(eq(67L))).thenReturn(Optional.of(rec)); 
+
+        //act
+        MvcResult response = mockMvc
+                .perform(put("/api/recommendationrequest/professor?id=67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //assert
+        verify(recommendationRequestRepository, times(1)).findById(67L);
+        verify(recommendationRequestRepository, times(1)).save(refEq(rec_corrected, "completionDate"));
+        
+        String responseString = response.getResponse().getContentAsString();
+        String expectedJson = mapper.writeValueAsString(rec_corrected);
+
         assertEquals(expectedJson, responseString);
     }
 


### PR DESCRIPTION
Closes #21 and Closes #6

In this PR we add backend code to store the completion date when a professor changes the status of a recommendation request from PENDING to either COMPLETED or DENIED.

To test, visit: https://rec-dk.dokku-16.cs.ucsb.edu/

1. Login
2. Go to Admin -> Users
3. Toggle Student and Professor to True.
4. Pending Requests should now appear in the Navbar (if nothing appears, refresh the page)
5. Go into Swagger, use POST to create a recommendation request
6. View pending request in the recommendation request table. In the status column, change status from PENDING to COMPLETED.
7. Request will disappear from the Pending Requests Page and will reappear if you navigate to the Completed Requests Page, and will display the completion date in the Completion Date column.
<img width="1389" alt="Screenshot 2025-05-19 at 11 49 17 PM" src="https://github.com/user-attachments/assets/ee96b7a6-5c48-478f-98a4-5f0800a82471" />

Storybook: https://6823e9b0211c5dd7ddc2cdd3-xaplixqjne.chromatic.com/?path=/docs/pages-requests-completedrequestspage--docs