### PR TITLE
Dk - fixed delete button functionality

### DIFF
--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -32,7 +32,7 @@ export default function RecommendationRequestTable({
     : "/api/recommendationrequest/requester/all";
 
   const deleteMutation = useBackendMutation(
-    cellToAxiosParamsDelete,
+    cell => cellToAxiosParamsDelete(cell, hasRole(currentUser, "ROLE_ADMIN")),
     { onSuccess: onDeleteSuccess },
     [apiEndpoint],
   );

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -32,7 +32,7 @@ export default function RecommendationRequestTable({
     : "/api/recommendationrequest/requester/all";
 
   const deleteMutation = useBackendMutation(
-    cell => cellToAxiosParamsDelete(cell, hasRole(currentUser, "ROLE_ADMIN")),
+    (cell) => cellToAxiosParamsDelete(cell, hasRole(currentUser, "ROLE_ADMIN")),
     { onSuccess: onDeleteSuccess },
     [apiEndpoint],
   );

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -5,9 +5,10 @@ export function onDeleteSuccess(message) {
   toast(message);
 }
 
-export function cellToAxiosParamsDelete(cell) {
+export function cellToAxiosParamsDelete(cell, isAdmin) {
+  const urlCalled = isAdmin ? "/api/recommendationrequest/admin" : "/api/recommendationrequest"
   return {
-    url: "/api/recommendationrequest",
+    url: urlCalled,
     method: "DELETE",
     params: {
       id: cell.row.values.id,

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -6,7 +6,9 @@ export function onDeleteSuccess(message) {
 }
 
 export function cellToAxiosParamsDelete(cell, isAdmin) {
-  const urlCalled = isAdmin ? "/api/recommendationrequest/admin" : "/api/recommendationrequest"
+  const urlCalled = isAdmin
+    ? "/api/recommendationrequest/admin"
+    : "/api/recommendationrequest";
   return {
     url: urlCalled,
     method: "DELETE",

--- a/frontend/src/tests/utils/RecommendationRequestUtils.test.js
+++ b/frontend/src/tests/utils/RecommendationRequestUtils.test.js
@@ -49,6 +49,22 @@ describe("RecommendationRequestUtils", () => {
       });
     });
   });
+  describe("cellToAxiosParamsDeleteAdmin", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell, true);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/recommendationrequest/admin",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
   describe("onUpdateStatusSuccess", () => {
     test("It puts the message on console.log and in a toast", () => {
       // arrange


### PR DESCRIPTION
Closes #42 

In this PR I added a conditional check that determines which delete endpoint to call based on if the user has the ADMIN role or not.

Previously, when a user with role ADMIN tried to delete a request, an Axios Error would occur and the delete button wouldn't work. Now, admin users can delete any requests and no error occurs. Delete functionality also works as normal for standard users and professors.

To test, visit: https://rec-dk.dokku-16.cs.ucsb.edu/

1. Login
2. Go to Admin -> Users
3. Toggle Admin and Professor to True.
4. Logout, then Login again with a different email
5. Go into Swagger, use POST to create a recommendation request, set the professor as your first email
6. Logout and go back to your first email
7. Go to pending requests, click the delete button on the request and it will successfully be deleted.