### PR TITLE
Jl remove student everywhere

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9607,9 +9607,7 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001651",
       "funding": [
         {
           "type": "opencollective",

--- a/src/main/java/edu/ucsb/cs156/rec/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/rec/config/SecurityConfig.java
@@ -127,10 +127,6 @@ public class SecurityConfig {
           if(getProfessor(email)){
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
           }
-
-          if(getStudent(email)){
-            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_STUDENT"));
-          }
         }
 
       });
@@ -158,11 +154,6 @@ public class SecurityConfig {
   public boolean getProfessor(String email) {
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getProfessor();
-  }
-
-  public boolean getStudent(String email) {
-    Optional<User> u = userRepository.findByEmail(email);
-    return u.isPresent() && u.get().getStudent();
   }
 }
 

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -126,16 +126,4 @@ public class UsersController extends ApiController {
         userRepository.save(user);
         return genericMessage("User with id %s has toggled professor status to %s".formatted(id, user.getProfessor()));
     }
-
-    @Operation(summary = "Toggle the student field")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/toggleStudent")
-    public Object toggleStudent( @Parameter(name = "id", description = "Long, id number of user to toggle their student field", example = "1", required = true) @RequestParam Long id){
-        User user = userRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
-
-        user.setStudent(!user.getStudent());
-        userRepository.save(user);
-        return genericMessage("User with id %s has toggled student status to %s".formatted(id, user.getStudent()));
-    }
 }

--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -37,5 +37,7 @@ public class User {
   @Builder.Default
   private Boolean admin=false;
   @Builder.Default
+  private Boolean student=true;
+  @Builder.Default
   private Boolean professor=false;
 }

--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -37,7 +37,5 @@ public class User {
   @Builder.Default
   private Boolean admin=false;
   @Builder.Default
-  private Boolean student=true;
-  @Builder.Default
   private Boolean professor=false;
 }

--- a/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
@@ -48,8 +48,7 @@ public class RoleInterceptor implements HandlerInterceptor {
                 Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
                 Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
                         grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
-                                && !grantedAuth.getAuthority().equals("ROLE_PROFESSOR")
-                                && !grantedAuth.getAuthority().equals("ROLE_STUDENT"))
+                                && !grantedAuth.getAuthority().equals("ROLE_PROFESSOR"))
                         .collect(Collectors.toSet());
                 if (user.getAdmin()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
@@ -58,7 +57,7 @@ public class RoleInterceptor implements HandlerInterceptor {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
                 }
                 if (user.getStudent()) {
-                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_STUDENT"));
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
                 }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));

--- a/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
@@ -56,9 +56,6 @@ public class RoleInterceptor implements HandlerInterceptor {
                 if (user.getProfessor()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
                 }
-                if (user.getStudent()) {
-                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
-                }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
                 SecurityContextHolder.getContext().setAuthentication(newAuth);

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
@@ -217,44 +217,6 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals("User with id 15 not found", json.get("message"));
   }
 
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_can_toggle_student() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(false).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-             .andExpect(status().isOk()).andReturn();
-    
-    verify(userRepository, times(1)).findById(17L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 17 has toggled student status to true", json.get("message"));
-  }
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_can_toggle_student_flip() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).student(true).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=17").with(csrf()))
-             .andExpect(status().isOk()).andReturn();
-    
-    verify(userRepository, times(1)).findById(17L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 17 has toggled student status to false", json.get("message"));
-  }
-
-  @WithMockUser(roles = { "ADMIN", "USER" })
-  @Test
-  public void admin_cant_toggle_student_nonexistent() throws Exception{
-     User user1 = User.builder().email("joegaucho@ucsb.edu").id(17L).build();
-     when(userRepository.findById(eq(17L))).thenReturn(Optional.of(user1));
-     MvcResult response = mockMvc.perform(post("/api/admin/users/toggleStudent?id=15").with(csrf()))
-             .andExpect(status().is(404)).andReturn();
-    
-    verify(userRepository, times(1)).findById(15L);
-    Map<String, Object> json = responseToJson(response);
-    assertEquals("User with id 15 not found", json.get("message"));
-  }
-
   @WithMockUser(roles = { "USER" })
   @Test
   public void non_admin_can_get_all_professors() throws Exception{
@@ -268,7 +230,6 @@ public class UsersControllerTests extends ControllerTestCase {
     assertTrue(responseString.contains("Phill Conrad"));
     assertTrue(responseString.contains("1"));
     assertFalse(responseString.contains("email"));
-
   }
 
 }

--- a/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
@@ -141,13 +141,10 @@ public class RoleInterceptorTests extends ControllerTestCase{
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
         boolean role_professor = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_PROFESSOR"));
-        boolean role_student = authorities.stream()
-            .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_STUDENT"));
         boolean role_user = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_USER"));
         assertTrue(role_admin, "ROLE_ADMIN should be in roles list");
         assertTrue(role_professor, "ROLE_PROFESSOR should be in roles list");
-        assertTrue(role_student, "ROLE_STUDENT should be in roles list");
         assertTrue(role_user, "ROLE_USER should be in roles list");
 
     }
@@ -185,13 +182,10 @@ public class RoleInterceptorTests extends ControllerTestCase{
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
         boolean role_professor = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_PROFESSOR"));
-        boolean role_student = authorities.stream()
-            .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_STUDENT"));
         boolean role_user = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_USER"));
         assertFalse(role_admin, "ROLE_ADMIN should not be in roles list");
         assertTrue(role_professor, "ROLE_PROFESSOR should be in roles list");
-        assertFalse(role_student, "ROLE_STUDENT should not be in roles list");
         assertTrue(role_user, "ROLE_USER should be in roles list");
     }
 
@@ -228,13 +222,10 @@ public class RoleInterceptorTests extends ControllerTestCase{
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
         boolean role_professor = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_PROFESSOR"));
-        boolean role_student = authorities.stream()
-            .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_STUDENT"));
         boolean role_user = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_USER"));
         assertTrue(role_admin, "ROLE_ADMIN should be in roles list");
         assertTrue(role_professor, "ROLE_PROFESSOR should be in roles list");
-        assertTrue(role_student, "ROLE_STUDENT should be in roles list");
         assertTrue(role_user, "ROLE_USER should be in roles list");
     }
 
@@ -271,13 +262,10 @@ public class RoleInterceptorTests extends ControllerTestCase{
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
         boolean role_professor = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_PROFESSOR"));
-        boolean role_student = authorities.stream()
-            .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_STUDENT"));
         boolean role_user = authorities.stream()
             .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_USER"));
         assertTrue(role_admin, "ROLE_ADMIN should be in roles list");
         assertFalse(role_professor, "ROLE_PROFESSOR should not be in roles list");
-        assertFalse(role_student, "ROLE_STUDENT should be not in roles list");
         assertTrue(role_user, "ROLE_USER should be in roles list");
     }
             

--- a/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
@@ -113,7 +113,6 @@ public class RoleInterceptorTests extends ControllerTestCase{
                 .email("nogaucho@ucsb.edu")
                 .id(15L)
                 .admin(false)
-                .student(false)
                 .professor(false)
                 .build();
         when(userRepository.findByEmail("nogaucho@ucsb.edu")).thenReturn(Optional.of(user));
@@ -155,7 +154,6 @@ public class RoleInterceptorTests extends ControllerTestCase{
                 .email("joegaucho@ucsb.edu")
                 .id(15L)
                 .admin(false)
-                .student(false)
                 .professor(true)
                 .build();
 
@@ -195,7 +193,6 @@ public class RoleInterceptorTests extends ControllerTestCase{
                 .email("joegaucho@ucsb.edu")
                 .id(15L)
                 .admin(true)
-                .student(true)
                 .professor(true)
                 .build();
 
@@ -235,7 +232,6 @@ public class RoleInterceptorTests extends ControllerTestCase{
                 .email("joegaucho@ucsb.edu")
                 .id(15L)
                 .admin(true)
-                .student(false)
                 .professor(false)
                 .build();
 

--- a/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/rec/web/HomePageWebIT.java
@@ -48,8 +48,7 @@ public class HomePageWebIT {
         String url = String.format("http://localhost:%d/", port);
         page.navigate(url);
 
-        assertThat(page.getByText("This is a webapp containing a bunch of different Spring Boot/React examples."))
+        assertThat(page.getByText("This is a webapp that assists students and professors in creating and managing recommendation letter requests."))
                 .isVisible();
     }
-
 }


### PR DESCRIPTION
closes #14 

merge after #28 and #35

In this PR I remove all of the student role from the code base. If you open https://rec-jl.dokku-16.cs.ucsb.edu/ log in with an admin email and go to swagger, current user information should look like this.

Before:
![image](https://github.com/user-attachments/assets/4d66e904-e8b5-497b-bb78-975209af680e)

After:
![image](https://github.com/user-attachments/assets/fac35714-7fb0-48c7-a1b4-7b2ba94034da)
