### PR TITLE
Cl rec admin page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,7 +24,11 @@ function App() {
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <>
             <Route exact path="/admin/users" element={<AdminUsersPage />} />
-            <Route exact path="/admin/requests" element={<AdminRequestsPage />} />
+            <Route
+              exact
+              path="/admin/requests"
+              element={<AdminRequestsPage />}
+            />
           </>
         )}
         {(hasRole(currentUser, "ROLE_PROFESSOR") ||

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
+import AdminRequestsPage from "main/pages/AdminRequestsPage";
 
 import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
 import CompletedRequestsPage from "main/pages/Requests/CompletedRequestsPage";
@@ -21,7 +22,10 @@ function App() {
         <Route exact path="/" element={<HomePage />} />
         <Route exact path="/profile" element={<ProfilePage />} />
         {hasRole(currentUser, "ROLE_ADMIN") && (
-          <Route exact path="/admin/users" element={<AdminUsersPage />} />
+          <>
+            <Route exact path="/admin/users" element={<AdminUsersPage />} />
+            <Route exact path="/admin/requests" element={<AdminRequestsPage />} />
+          </>
         )}
         {(hasRole(currentUser, "ROLE_PROFESSOR") ||
           hasRole(currentUser, "ROLE_STUDENT")) && (

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,6 +56,7 @@ export default function AppNavbar({
                   data-testid="appnavbar-admin-dropdown"
                 >
                   <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
+                  <NavDropdown.Item href="/admin/requests">Requests</NavDropdown.Item>
                 </NavDropdown>
               )}
               {(hasRole(currentUser, "ROLE_PROFESSOR") ||

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,7 +56,9 @@ export default function AppNavbar({
                   data-testid="appnavbar-admin-dropdown"
                 >
                   <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
-                  <NavDropdown.Item href="/admin/requests">Requests</NavDropdown.Item>
+                  <NavDropdown.Item href="/admin/requests">
+                    Requests
+                  </NavDropdown.Item>
                 </NavDropdown>
               )}
               {(hasRole(currentUser, "ROLE_PROFESSOR") ||

--- a/frontend/src/main/pages/AdminRequestsPage.js
+++ b/frontend/src/main/pages/AdminRequestsPage.js
@@ -17,7 +17,7 @@ const AdminRequestsPage = () => {
   return (
     <BasicLayout>
       <h2>Requests</h2>
-      <RequestsTable requests={requests} currentUser={{ role: "ROLE_ADMIN" }} />
+      <RequestsTable requests={requests} />
     </BasicLayout>
   );
 };

--- a/frontend/src/main/pages/AdminRequestsPage.js
+++ b/frontend/src/main/pages/AdminRequestsPage.js
@@ -1,0 +1,25 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RequestsTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+
+import { useBackend } from "main/utils/useBackend";
+const AdminRequestsPage = () => {
+  const {
+    data: requests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/recommendationrequest/admin/all"],
+    { method: "GET", url: "/api/recommendationrequest/admin/all" },
+    [],
+  );
+
+  return (
+    <BasicLayout>
+      <h2>Requests</h2>
+      <RequestsTable requests={requests} currentUser={{ role: "ROLE_ADMIN" }} />
+    </BasicLayout>
+  );
+};
+
+export default AdminRequestsPage;

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -70,47 +70,4 @@ describe("AdminRequestsPage tests", () => {
       screen.queryByTestId(`${testId}-cell-row-0-col-id`),
     ).not.toBeInTheDocument();
   });
-
-  test("renders admin-specific table when user has ROLE_ADMIN", async () => {
-    const queryClient = new QueryClient();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, { ...apiCurrentUserFixtures.adminUser, role: "ROLE_ADMIN" });
-    axiosMock
-      .onGet("/api/recommendationrequest/admin/all")
-      .reply(200, recommendationRequestFixtures.threeRecommendations);
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <AdminRequestsPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-
-    expect(await screen.findByText("Requests")).toBeInTheDocument();
-    expect(
-      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
-    ).toBeInTheDocument();
-  });
-
-  test("renders fallback when user has no role", async () => {
-    const queryClient = new QueryClient();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, { ...apiCurrentUserFixtures.adminUser, role: "" });
-    axiosMock
-      .onGet("/api/recommendationrequest/admin/all")
-      .reply(200, recommendationRequestFixtures.threeRecommendations);
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <AdminRequestsPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-
-    expect(await screen.findByText("Requests")).toBeInTheDocument();
-  });
 });

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -2,7 +2,7 @@ import { render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import AdminRequestsPage from "main/pages/AdminRequestsPage";
-import recommendationRequestFixtures from "fixtures/recommendationRequestFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import mockConsole from "jest-mock-console";
@@ -29,7 +29,7 @@ describe("AdminRequestsPage tests", () => {
   test("renders without crashing on three requests", async () => {
     const queryClient = new QueryClient();
     axiosMock
-      .onGet("/api/recomendationrequest/admin/all")
+      .onGet("/api/recommendationrequest/admin/all")
       .reply(200, recommendationRequestFixtures.threeRecommendations);
 
     render(
@@ -44,7 +44,7 @@ describe("AdminRequestsPage tests", () => {
 
   test("renders empty table when backend unavailable", async () => {
     const queryClient = new QueryClient();
-    axiosMock.onGet("/api/recomendationrequest/admin/all").timeout();
+    axiosMock.onGet("/api/recommendationrequest/admin/all").timeout();
 
     const restoreConsole = mockConsole();
 
@@ -62,7 +62,7 @@ describe("AdminRequestsPage tests", () => {
 
     const errorMessage = console.error.mock.calls[0][0];
     expect(errorMessage).toMatch(
-      "Error communicating with backend via GET on /api/recomendationrequest/admin/all",
+      "Error communicating with backend via GET on /api/recommendationrequest/admin/all",
     );
     restoreConsole();
 

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -1,8 +1,8 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import AdminUsersPage from "main/pages/AdminRequestsPage";
-import usersFixtures from "fixtures/recommendationRequestFixtures";
+import AdminRequestsPage from "main/pages/AdminRequestsPage";
+import recommendationRequestFixtures from "fixtures/recommendationRequestFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import mockConsole from "jest-mock-console";

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -1,0 +1,71 @@
+import { render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import AdminUsersPage from "main/pages/AdminRequestsPage";
+import usersFixtures from "fixtures/recommendationRequestFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import mockConsole from "jest-mock-console";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("AdminRequestsPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "RequestsTable";
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  test("renders without crashing on three requests", async () => {
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/admin/requests").reply(200, recommendationRequestFixtures.threeRecommendations);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    await screen.findByText("Requests");
+  });
+
+  test("renders empty table when backend unavailable", async () => {
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/admin/requests").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/admin/requests",
+    );
+    restoreConsole();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -28,7 +28,9 @@ describe("AdminRequestsPage tests", () => {
 
   test("renders without crashing on three requests", async () => {
     const queryClient = new QueryClient();
-    axiosMock.onGet("/api/admin/requests").reply(200, recommendationRequestFixtures.threeRecommendations);
+    axiosMock
+      .onGet("/api/admin/requests")
+      .reply(200, recommendationRequestFixtures.threeRecommendations);
 
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -13,7 +13,7 @@ import AxiosMockAdapter from "axios-mock-adapter";
 describe("AdminRequestsPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const testId = "RequestsTable";
+  const testId = "RecommendationRequestTable";
 
   beforeEach(() => {
     axiosMock.reset();
@@ -69,5 +69,48 @@ describe("AdminRequestsPage tests", () => {
     expect(
       screen.queryByTestId(`${testId}-cell-row-0-col-id`),
     ).not.toBeInTheDocument();
+  });
+
+  test("renders admin-specific table when user has ROLE_ADMIN", async () => {
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, { ...apiCurrentUserFixtures.adminUser, role: "ROLE_ADMIN" });
+    axiosMock
+      .onGet("/api/recommendationrequest/admin/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendations);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Requests")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toBeInTheDocument();
+  });
+
+  test("renders fallback when user has no role", async () => {
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, { ...apiCurrentUserFixtures.adminUser, role: "" });
+    axiosMock
+      .onGet("/api/recommendationrequest/admin/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendations);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Requests")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -29,7 +29,7 @@ describe("AdminRequestsPage tests", () => {
   test("renders without crashing on three requests", async () => {
     const queryClient = new QueryClient();
     axiosMock
-      .onGet("/api/admin/requests")
+      .onGet("/api/recomendationrequest/admin/all")
       .reply(200, recommendationRequestFixtures.threeRecommendations);
 
     render(
@@ -44,7 +44,7 @@ describe("AdminRequestsPage tests", () => {
 
   test("renders empty table when backend unavailable", async () => {
     const queryClient = new QueryClient();
-    axiosMock.onGet("/api/admin/requests").timeout();
+    axiosMock.onGet("/api/recomendationrequest/admin/all").timeout();
 
     const restoreConsole = mockConsole();
 
@@ -62,7 +62,7 @@ describe("AdminRequestsPage tests", () => {
 
     const errorMessage = console.error.mock.calls[0][0];
     expect(errorMessage).toMatch(
-      "Error communicating with backend via GET on /api/admin/requests",
+      "Error communicating with backend via GET on /api/recomendationrequest/admin/all",
     );
     restoreConsole();
 


### PR DESCRIPTION
Closes #17 

MERGE #39 FIRST

Created admin page that lists all recommendation requests regardless of status.

<img width="1512" alt="Screenshot 2025-05-21 at 7 39 24 PM" src="https://github.com/user-attachments/assets/c27515ba-d2c0-4c0d-a3c7-997366882f47" />

Test by:
- Go to https://rec-dev-applechristian.dokku-16.cs.ucsb.edu
- Login as admin
- Create requests on swagger
- Under Admin dropdown menu, click requests