### PR TITLE
jh - hardcoded request types for request table

### DIFF
--- a/src/main/resources/db/migration/changes/RequestType.json
+++ b/src/main/resources/db/migration/changes/RequestType.json
@@ -1,50 +1,111 @@
 {
-    "databaseChangeLog": [
-      {
-        "changeSet": {
-          "id": "RequestType-1",
-          "author": "MikeP",
-          "preConditions": [
-            {
-              "onFail": "MARK_RAN"
-            },
-            {
-              "not": [
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "RequestType-1",
+        "author": "MikeP",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "REQUESTTYPE"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
                 {
-                  "tableExists": {
-                    "tableName": "REQUESTTYPE"
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "REQUESTTYPE_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "REQUEST_TYPE",
+                    "type": "VARCHAR(255)"
                   }
                 }
-              ]
+              ],
+              "tableName": "REQUESTTYPE"
             }
-          ],
-          "changes": [
-            {
-              "createTable": {
-                "columns": [
-                  {
-                    "column": {
-                      "autoIncrement": true,
-                      "constraints": {
-                        "primaryKey": true,
-                        "primaryKeyName": "REQUESTTYPE_PK"
-                      },
-                      "name": "ID",
-                      "type": "BIGINT"
-                    }
-                  },
-                  {
-                    "column": {
-                      "name": "REQUEST_TYPE",
-                      "type": "VARCHAR(255)"
-                    }
-                  }
-                ],
-                "tableName": "REQUESTTYPE"
-              }
-            }
-          ]
-        }
+          }
+        ]
       }
-    ]
-  }
+    },
+    {
+      "changeSet": {
+        "id": "RequestType-2-add-hardcoded-types",
+        "author": "YourName",
+        "preConditions": [
+          {
+            "onFail": "CONTINUE"
+          },
+          {
+            "tableExists": {
+              "tableName": "REQUESTTYPE"
+            }
+          }
+        ],
+        "changes": [
+          {
+            "sql": {
+              "sql": "INSERT INTO REQUESTTYPE (REQUEST_TYPE) SELECT 'Letter of Recommendation' WHERE NOT EXISTS (SELECT 1 FROM REQUESTTYPE WHERE REQUEST_TYPE = 'Letter of Recommendation')"
+            }
+          },
+          {
+            "sql": {
+              "sql": "INSERT INTO REQUESTTYPE (REQUEST_TYPE) SELECT 'Graduate School Recommendation' WHERE NOT EXISTS (SELECT 1 FROM REQUESTTYPE WHERE REQUEST_TYPE = 'Graduate School Recommendation')"
+            }
+          },
+          {
+            "sql": {
+              "sql": "INSERT INTO REQUESTTYPE (REQUEST_TYPE) SELECT 'Scholarship Recommendation' WHERE NOT EXISTS (SELECT 1 FROM REQUESTTYPE WHERE REQUEST_TYPE = 'Scholarship Recommendation')"
+            }
+          },
+          {
+            "sql": {
+              "sql": "INSERT INTO REQUESTTYPE (REQUEST_TYPE) SELECT 'Job Recommendation' WHERE NOT EXISTS (SELECT 1 FROM REQUESTTYPE WHERE REQUEST_TYPE = 'Job Recommendation')"
+            }
+          },
+          {
+            "sql": {
+              "sql": "INSERT INTO REQUESTTYPE (REQUEST_TYPE) SELECT 'Research Program Recommendation' WHERE NOT EXISTS (SELECT 1 FROM REQUESTTYPE WHERE REQUEST_TYPE = 'Research Program Recommendation')"
+            }
+          },
+          {
+            "sql": {
+              "sql": "INSERT INTO REQUESTTYPE (REQUEST_TYPE) SELECT 'Fellowship Recommendation' WHERE NOT EXISTS (SELECT 1 FROM REQUESTTYPE WHERE REQUEST_TYPE = 'Fellowship Recommendation')"
+            }
+          },
+          {
+            "sql": {
+              "sql": "INSERT INTO REQUESTTYPE (REQUEST_TYPE) SELECT 'Internship Recommendation' WHERE NOT EXISTS (SELECT 1 FROM REQUESTTYPE WHERE REQUEST_TYPE = 'Internship Recommendation')"
+            }
+          }
+        ],
+        "rollback": [
+          {
+            "sql": {
+              "sql": "DELETE FROM REQUESTTYPE WHERE REQUEST_TYPE IN ('Letter of Recommendation', 'Graduate School Recommendation', 'Scholarship Recommendation', 'Job Recommendation', 'Research Program Recommendation', 'Fellowship Recommendation', 'Internship Recommendation')"
+            }
+          }
+        ],
+        "comment": "Add hardcoded request types, checking for each one to see if it is already there before loading it"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #22 

In this PR, we added hardcoded request types that are automatically loaded into the database at startup. We did this by updating RequestType.json with a new Liquibase changeset, and added 7 predefined request types.

Swagger:

![image](https://github.com/user-attachments/assets/17ee6d33-e58c-4f73-93a2-a85022095493)