### PR TITLE
jl - bug fix, removed extra role_student from the codebase

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,8 +31,7 @@ function App() {
             />
           </>
         )}
-        {(hasRole(currentUser, "ROLE_PROFESSOR") ||
-          hasRole(currentUser, "ROLE_STUDENT")) && (
+        {(hasRole(currentUser, "ROLE_PROFESSOR")) && (
           <>
             <Route
               exact

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,7 +31,8 @@ function App() {
             />
           </>
         )}
-        {(hasRole(currentUser, "ROLE_PROFESSOR")) && (
+        {(hasRole(currentUser, "ROLE_PROFESSOR") ||
+          hasRole(currentUser, "ROLE_USER")) && (
           <>
             <Route
               exact

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,23 +31,25 @@ function App() {
             />
           </>
         )}
-        <>
-          <Route
-            exact
-            path="/requests/pending"
-            element={<PendingRequestsPage />}
-          />
-          <Route
-            exact
-            path="/requests/completed"
-            element={<CompletedRequestsPage />}
-          />
-          <Route
-            exact
-            path="/requests/statistics"
-            element={<StatisticsPage />}
-          />
-        </>
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route
+              exact
+              path="/requests/pending"
+              element={<PendingRequestsPage />}
+            />
+            <Route
+              exact
+              path="/requests/completed"
+              element={<CompletedRequestsPage />}
+            />
+            <Route
+              exact
+              path="/requests/statistics"
+              element={<StatisticsPage />}
+            />
+          </>
+        )}
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,8 +31,6 @@ function App() {
             />
           </>
         )}
-        {(hasRole(currentUser, "ROLE_PROFESSOR") ||
-          hasRole(currentUser, "ROLE_USER")) && (
           <>
             <Route
               exact
@@ -50,7 +48,6 @@ function App() {
               element={<StatisticsPage />}
             />
           </>
-        )}
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,23 +31,23 @@ function App() {
             />
           </>
         )}
-          <>
-            <Route
-              exact
-              path="/requests/pending"
-              element={<PendingRequestsPage />}
-            />
-            <Route
-              exact
-              path="/requests/completed"
-              element={<CompletedRequestsPage />}
-            />
-            <Route
-              exact
-              path="/requests/statistics"
-              element={<StatisticsPage />}
-            />
-          </>
+        <>
+          <Route
+            exact
+            path="/requests/pending"
+            element={<PendingRequestsPage />}
+          />
+          <Route
+            exact
+            path="/requests/completed"
+            element={<CompletedRequestsPage />}
+          />
+          <Route
+            exact
+            path="/requests/statistics"
+            element={<StatisticsPage />}
+          />
+        </>
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -177,9 +177,6 @@ const apiCurrentUserFixtures = {
         authority: "ROLE_USER",
       },
       {
-        authority: "ROLE_STUDENT",
-      },
-      {
         authority: "SCOPE_https://www.googleapis.com/auth/userinfo.profile",
       },
       {
@@ -253,7 +250,6 @@ const currentUserFixtures = {
       rolesList: [
         "SCOPE_openid",
         "ROLE_USER",
-        "ROLE_STUDENT",
         "SCOPE_https://www.googleapis.com/auth/userinfo.profile",
         "SCOPE_https://www.googleapis.com/auth/userinfo.email",
       ],

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -118,7 +118,6 @@ const apiCurrentUserFixtures = {
       locale: null,
       hostedDomain: null,
       admin: false,
-      student: false,
       professor: true,
     },
     roles: [
@@ -166,7 +165,6 @@ const apiCurrentUserFixtures = {
       locale: null,
       hostedDomain: null,
       admin: false,
-      student: true,
       professor: false,
     },
     roles: [

--- a/frontend/src/fixtures/usersFixtures.js
+++ b/frontend/src/fixtures/usersFixtures.js
@@ -14,7 +14,6 @@ const usersFixtures = {
       hostedDomain: null,
       admin: false,
       professor: true,
-      student: false,
     },
     {
       id: 1,
@@ -30,7 +29,6 @@ const usersFixtures = {
       hostedDomain: "ucsb.edu",
       admin: true,
       professor: true,
-      student: false,
     },
   ],
   threeUsers: [
@@ -48,7 +46,6 @@ const usersFixtures = {
       hostedDomain: "ucsb.edu",
       admin: true,
       professor: false,
-      student: false,
     },
     {
       id: 2,
@@ -64,7 +61,6 @@ const usersFixtures = {
       hostedDomain: null,
       admin: false,
       professor: false,
-      student: true,
     },
     {
       id: 3,
@@ -80,7 +76,6 @@ const usersFixtures = {
       hostedDomain: null,
       admin: false,
       professor: true,
-      student: false,
     },
   ],
 };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -61,20 +61,17 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                 </NavDropdown>
               )}
-              {(hasRole(currentUser, "ROLE_PROFESSOR") ||
-                hasRole(currentUser, "ROLE_USER")) && (
-                <>
-                  <Nav.Link as={Link} to="/requests/pending">
-                    Pending Requests
-                  </Nav.Link>
-                  <Nav.Link as={Link} to="/requests/completed">
-                    Completed Requests
-                  </Nav.Link>
-                  <Nav.Link as={Link} to="/requests/statistics">
-                    Statistics
-                  </Nav.Link>
-                </>
-              )}
+              <>
+                <Nav.Link as={Link} to="/requests/pending">
+                  Pending Requests
+                </Nav.Link>
+                <Nav.Link as={Link} to="/requests/completed">
+                  Completed Requests
+                </Nav.Link>
+                <Nav.Link as={Link} to="/requests/statistics">
+                  Statistics
+                </Nav.Link>
+              </>
             </Nav>
 
             <Nav className="ml-auto">

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -61,8 +61,7 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                 </NavDropdown>
               )}
-              {(hasRole(currentUser, "ROLE_PROFESSOR") ||
-                hasRole(currentUser, "ROLE_STUDENT")) && (
+              {(hasRole(currentUser, "ROLE_PROFESSOR")) && (
                 <>
                   <Nav.Link as={Link} to="/requests/pending">
                     Pending Requests

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -61,7 +61,8 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                 </NavDropdown>
               )}
-              {(hasRole(currentUser, "ROLE_PROFESSOR")) && (
+              {(hasRole(currentUser, "ROLE_PROFESSOR") ||
+                hasRole(currentUser, "ROLE_USER")) && (
                 <>
                   <Nav.Link as={Link} to="/requests/pending">
                     Pending Requests

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -61,17 +61,19 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                 </NavDropdown>
               )}
-              <>
-                <Nav.Link as={Link} to="/requests/pending">
-                  Pending Requests
-                </Nav.Link>
-                <Nav.Link as={Link} to="/requests/completed">
-                  Completed Requests
-                </Nav.Link>
-                <Nav.Link as={Link} to="/requests/statistics">
-                  Statistics
-                </Nav.Link>
-              </>
+              {hasRole(currentUser, "ROLE_USER") && (
+                <>
+                  <Nav.Link as={Link} to="/requests/pending">
+                    Pending Requests
+                  </Nav.Link>
+                  <Nav.Link as={Link} to="/requests/completed">
+                    Completed Requests
+                  </Nav.Link>
+                  <Nav.Link as={Link} to="/requests/statistics">
+                    Statistics
+                  </Nav.Link>
+                </>
+              )}
             </Nav>
 
             <Nav className="ml-auto">

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -219,7 +219,7 @@ describe("AppNavbar tests", () => {
     expect(statisticsLink).toBeInTheDocument();
   });
 
-  test("the three prof pages do not show for normal users", async () => {
+  test("the three prof pages do show for normal users", async () => {
     const currentUser = currentUserFixtures.userOnly;
     const systemInfo = systemInfoFixtures.showingBoth;
     const doLogin = jest.fn();
@@ -236,9 +236,9 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.queryByText("Pending Requests")).not.toBeInTheDocument();
-    expect(screen.queryByText("Completed Requests")).not.toBeInTheDocument();
-    expect(screen.queryByText("Statistics")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pending Requests")).toBeInTheDocument();
+    expect(screen.queryByText("Completed Requests")).toBeInTheDocument();
+    expect(screen.queryByText("Statistics")).toBeInTheDocument();
   });
 
   test("the three prof pages do not show when not logged in", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -258,8 +258,8 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.getByText("Pending Requests")).toBeInTheDocument();
-    expect(screen.getByText("Completed Requests")).toBeInTheDocument();
-    expect(screen.getByText("Statistics")).toBeInTheDocument();
+    expect(screen.queryByText("Pending Requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("Completed Requests")).not.toBeInTheDocument();
+    expect(screen.queryByText("Statistics")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -236,9 +236,9 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.queryByText("Pending Requests")).toBeInTheDocument();
-    expect(screen.queryByText("Completed Requests")).toBeInTheDocument();
-    expect(screen.queryByText("Statistics")).toBeInTheDocument();
+    expect(screen.getByText("Pending Requests")).toBeInTheDocument();
+    expect(screen.getByText("Completed Requests")).toBeInTheDocument();
+    expect(screen.getByText("Statistics")).toBeInTheDocument();
   });
 
   test("the three prof pages do not show when not logged in", async () => {
@@ -258,8 +258,8 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.queryByText("Pending Requests")).not.toBeInTheDocument();
-    expect(screen.queryByText("Completed Requests")).not.toBeInTheDocument();
-    expect(screen.queryByText("Statistics")).not.toBeInTheDocument();
+    expect(screen.getByText("Pending Requests")).toBeInTheDocument();
+    expect(screen.getByText("Completed Requests")).toBeInTheDocument();
+    expect(screen.getByText("Statistics")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -70,7 +70,9 @@ describe("PendingRequestsPage tests", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Pending Requests")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Pending Requests" }),
+      ).toBeInTheDocument();
     });
 
     expect(axiosMock.history.get.length).toBe(3);

--- a/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
@@ -56,6 +56,7 @@ public class RoleInterceptor implements HandlerInterceptor {
                 if (user.getProfessor()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
                 }
+                revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
                 SecurityContextHolder.getContext().setAuthentication(newAuth);

--- a/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
@@ -88,7 +88,6 @@ public class RoleInterceptorTests extends ControllerTestCase{
         credentials.add(new SimpleGrantedAuthority("ROLE_USER"));
         credentials.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
         credentials.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
-        credentials.add(new SimpleGrantedAuthority("ROLE_STUDENT"));
 
         OAuth2User user = new DefaultOAuth2User(credentials,values,"email");
         Authentication auth = new OAuth2AuthenticationToken(user, credentials, "google");


### PR DESCRIPTION
In this PR I remove some additional ROLE_STUDENT that was found in the code. I also update some of the tests to reflect the pending requests, completed requests, and statistics pages to show up for all users, but only if logged in.

To test:
- open https://rec-qa.dokku-16.cs.ucsb.edu/
- when not logged in, there are no pending requests, completed requests, and statistics on the navbar
- when logged in as a professor or not, admin or not, the pending requests, completed requests, and statistics pages are on the navbar and are accessible